### PR TITLE
Removed obsolete information

### DIFF
--- a/src/groovy/org/codehaus/groovy/grails/plugins/jasper/JasperReportDef.groovy
+++ b/src/groovy/org/codehaus/groovy/grails/plugins/jasper/JasperReportDef.groovy
@@ -89,8 +89,7 @@ class JasperReportDef implements Serializable {
 
   /**
    * Looks for the report file in the filesystem. The file extension can either be .jasper
-   * or .jrxml. if japser.compile.files is set to true the report will be compiled and stored
-   * in the same folder as the jrxml file.
+   * or .jrxml.
    * @return the report as Resource
    * @throws Exception , report file not found
    */


### PR DESCRIPTION
The jasper.compile.files options was related to [this code](https://code.google.com/p/baldurian-grails-plugins/source/browse/trunk/grails-jasper/trunk/src/groovy/org/codehaus/groovy/grails/plugins/jasper/JasperReportDef.groovy#103) that isn't more present actually.

Btw, there is also a typo in the word 'japser'.
